### PR TITLE
Add quotes in shell initialization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ go install github.com/barthr/redo@latest
 
 *After downloading add the following line to your* `~/.bashrc` or `~/.zshrc`
 ```bash
-source $(redo alias-file)
+source "$(redo alias-file)"
 ```
 This will make sure that the aliases from redo are loaded on every shell session.
 


### PR DESCRIPTION
Since the user’s config path could be in `~/Library/Application Support` and `source` will think there are multiple files when it hits the spaces.