### PR TITLE
location of aliases on macos contains spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ go install github.com/barthr/redo@latest
 
 *After downloading add the following line to your* `~/.bashrc` or `~/.zshrc`
 ```bash
-source $(redo alias-file)
+source "$(redo alias-file)"
 ```
 This will make sure that the aliases from redo are loaded on every shell session.
 


### PR DESCRIPTION
Quote the file path so zsh/bash treats it as a single path

On my machine the location was 

```
/Users/${USER}/Library/Application Support/redo/aliases
```